### PR TITLE
Updated the Gateway Address Bug returning Silo Endpoint for Client

### DIFF
--- a/src/Orleans.Providers.Marten.Clustering/MartenGatewayListProvider.cs
+++ b/src/Orleans.Providers.Marten.Clustering/MartenGatewayListProvider.cs
@@ -50,7 +50,13 @@ public class MartenGatewayListProvider : IGatewayListProvider
                 .Select(m => m.Entry)
                 .ToListAsync();
 
-            var results = members.Select(m => m.SiloAddress.ToGatewayUri()).ToList();
+            var results = members.Select(m =>
+            {
+                var gatewayAddress = SiloAddress.New(m.SiloAddress.Endpoint.Address,
+                    m.ProxyPort ?? m.SiloAddress.Endpoint.Port,
+                    m.SiloAddress.Generation);
+                return gatewayAddress.ToGatewayUri();
+            }).ToList();
 
             _logger.LogTraceListedGateways(_clusterId);
             return results;


### PR DESCRIPTION
The Gateway Provider was returning the SiloAddress without any transformation this will cuase all Client request to go to the Silo Clustering Port instead of the gateway Port This PR fixes that  